### PR TITLE
Allow more attributes on `<style>` tags

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -133,7 +133,7 @@ class Formatter implements vscode.DocumentFormattingEditProvider {
       };
 
       // Select text that is contained between <style lang="stylus"> and </style>
-      const startStyleMatch = text.match(/<style(?:\s+scoped)?\s+lang="stylus"(?:\s+scoped)?\s*>/);
+      const startStyleMatch = text.match(/<style[^>]*\s+lang="stylus"[^>]*>/);
       const startStyleTag = startStyleMatch?.[0];
       const startStyle = startStyleMatch?.index;
       if (startStyleTag && startStyle) {


### PR DESCRIPTION
Hi, thanks for this extension :+1: 

The current regex did not support these valid stylus tags (but there are probably more valid attributes than this, so I made it less strict):

```html
<style lang="stylus" rel="stylesheet/stylus" scoped>
```
```html
<style lang="stylus" rel="stylesheet/stylus">
```

```html
<style rel="stylesheet/stylus" lang="stylus">
```